### PR TITLE
install rclone in cvmfs-client

### DIFF
--- a/cvmfs-client/Dockerfile
+++ b/cvmfs-client/Dockerfile
@@ -7,12 +7,19 @@ RUN yum -y install https://repo.opensciencegrid.org/osg/3.5/osg-3.5-el7-release-
                    epel-release \
                    yum-plugin-priorities && \
     yum -y install  \
+                   unzip \
                    osg-oasis \
 		cvmfs-config-default \
                    redhat-lsb-core \
                    singularity && \
     yum clean all && \
-    rm -rf /var/cache/yum/*
+    rm -rf /var/cache/yum/* && \
+    curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip && \
+    unzip rclone-current-linux-amd64.zip && \
+    cd rclone-*-linux-amd64 && \
+    cp rclone /usr/bin/ && \
+    chmod 755 /usr/bin/rclone
+
 
 COPY cvmfs_default.local /etc/cvmfs/default.local
 


### PR DESCRIPTION
Install rclone in `cvmfs-client` by downloading, unpacking, and moving the binary to `/usr/bin`.  This requires `unzip` which is a new dependency.

There are a few other ways to install rclone that I discarded, but I'm happy to change if you recommend:

* The one-line script install at https://rclone.org/install/ will likely work, but I was worried about dependency changes.  Probably would be fine!
* We could install with `snap` but then we'd have to install `snap`!  `unzip` seemed like a lighter dependency.